### PR TITLE
Expose /run/udev to the sandbox

### DIFF
--- a/org.entangle_photo.Manager.json
+++ b/org.entangle_photo.Manager.json
@@ -11,6 +11,7 @@
         "--socket=wayland",
 	"--filesystem=/media",
 	"--filesystem=/run/media",
+	"--filesystem=/run/udev",
 	"--filesystem=xdg-pictures",
         "--metadata=X-DConf=migrate-path=/org/entangle-photo/manager/",
         /* Needed for gvfs to work */


### PR DESCRIPTION
We need udev access to detect USB devices connecting/disconnecting

Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>